### PR TITLE
remove reference to team list

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -689,7 +689,7 @@ community discussion designed for Instructors getting ready to teach or having r
 
 #### Team
 
-group of Core Team members that work collaboratively to support a specific program area; for a list of our Teams, refer to [Quarterly Team Projects in The Carpentries](https://carpentries.org/core-team-projects/)
+group of Core Team members that work collaboratively to support a specific program area
 
 #### Themed Discussion Session
 


### PR DESCRIPTION
The team list it pointed to is very out of date. We don't keep a publically available list of teams and team memberships anymore.
