### PR TITLE
Update glossary.md

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -6,104 +6,108 @@
 
 #### Accessibility
 
-design of products, devices, services, or environments to be usable by all people regardless of their abilities; sometimes abbreviated as "a11y" where 11 stands for the number of letters between the first “a” and the last “y” in the word accessibility
+design of products, devices, services, or environments to be usable by all people regardless of their abilities; sometimes abbreviated as "a11y" where 11 stands for the number of letters between the first “a” and the last “y” in the word accessibility.
 
 #### AMY
 
-the internal database of The Carpentries; it allows the organisation to track programmatic activity including workshops, trainings, community roles and badges, and institutional memberships
+the internal database of The Carpentries; it allows the organisation to track programmatic activity including workshops, trainings, community roles and badges, and institutional memberships.
 
 ## B
 
 #### Badge
 
-indicator of a role in The Carpentries community that requires certification; typically, a certificate will be sent by email when a badge is conferred; refer to _**Certification**_
+indicator of a role in The Carpentries community that requires certification; typically, a certificate will be sent by email when a badge is conferred; refer to _**Certification**_.
 
 #### Blog Post
 
-written content shared on The Carpentries website written by the community or the Core Team to share information, community developments, or teaching tips and tricks 
+written content shared on The Carpentries website written by the community or the Core Team to share information, community developments, or teaching tips and tricks. 
+
+#### Board of Directors 
+
+the governing body of The Carpentries, to whom the Executive Director reports; the highest leadership body of The Carpentries project responsible for strategic and organisational planning, selecting the Executive Director and evaluating their performance, financial oversight, identifying revenue streams and resource development, approving and monitoring The Carpentries programs and services, and enhancing The Carpentries public image; members of the board also serve as advocates and ambassadors for the organisation, leveraging their networks to benefit the project’s reputation and fundraising; executes these responsibilities through a combination of quarterly Board of Directors meetings and regular correspondence and collaboration via email and online platforms.
 
 ## C
 
-#### Carpentries Clippings
+#### *Carpentries Clippings*
 
-monthly newsletter started in 2016 sent to an opt-in email list, featuring community news and announcements and including important updates from The Carpentries committees, task forces and programs, job postings, and related information for our community from other organisations
+monthly newsletter started in 2016 sent to an opt-in email list, featuring community news and announcements and including important updates from The Carpentries committees, task forces and programs, job postings, and related information for our community from other organisations.
 
 #### Carpentries Commons
 
-GitHub repository for open sharing of reusable material, such as text for grants, job or tenure applications, conference slide decks, workshop and training descriptions, and promotional materials; Core Team members have write access to add, edit and upload material to this repository; other community members will need to fork the repository and submit pull requests
+GitHub repository for open sharing of reusable material, such as text for grants, job or tenure applications, conference slide decks, workshop and training descriptions, and promotional materials; Core Team members have write access to add, edit and upload material to this repository; other community members will need to fork the repository and submit pull requests.
 
 #### Carpentries Incubator
 
-GitHub organisation hosting repositories of lessons being developed by community members; new lessons can be added to the Incubator by opening an issue on [the carpentries-incubator/proposals repository](https://github.com/carpentries-incubator/proposals)
+GitHub organisation hosting repositories of lessons being developed by community members; new lessons can be added to the Incubator by opening an issue on [the carpentries-incubator/proposals repository](https://github.com/carpentries-incubator/proposals).
 
 #### Carpentries Lab
 
-place for sharing high-quality, peer-reviewed lessons that follow best practices in pedagogy and the general teaching practices used in The Carpentries
+place for sharing high-quality, peer-reviewed lessons that follow best practices in pedagogy and the general teaching practices used in The Carpentries.
 
 #### CarpentryCon
 
-global community conference aimed at bringing The Carpentries community together for networking, knowledge and skills sharing, and collaborations around different initiatives and programs
+global community conference aimed at bringing The Carpentries community together for networking, knowledge and skills sharing, and collaborations around different initiatives and programs.
 
 #### CarpentryCon Committee
 
-members of the community who organise CarpentryCon
+members of the community who organise CarpentryCon.
 
 #### CarpentryConnect
 
-events organised by Subcommunity Coordinators to bring together members of a Carpentries’ subcommunity for knowledge exchange, collaboration, and networking; frequency, size and scope are determined by community members; refer to **_CarpentryConnect Planning Kit_**
+events organised by Subcommunity Coordinators to bring together members of a Carpentries’ subcommunity for knowledge exchange, collaboration, and networking; frequency, size and scope are determined by community members; refer to **_CarpentryConnect Planning Kit_**.
 
 #### [CarpentryConnect Planning Kit](https://carpentryconnect.org/)
 
-resource designed to guide community members as they organise CarpentryConnect events, whether online or in-person; resource includes checklists to work with, recommendations for best practices, and resources on event planning for further reading
+resource designed to guide community members as they organise CarpentryConnect events, whether online or in-person; resource includes checklists to work with, recommendations for best practices, and resources on event planning for further reading.
 
 #### [Carpentries Handbook](https://docs.carpentries.org/index.html)
 
-collection of information on Carpentries policies and procedures, including how to lead a workshop, how to develop and maintain lessons, how to participate in a training event, how to get involved in our global community, and information about Carpentries communication channels 
+collection of information on Carpentries policies and procedures, including how to lead a workshop, how to develop and maintain lessons, how to participate in a training event, how to get involved in our global community, and information about Carpentries communication channels. 
 
 #### Centrally-Organised Workshops
 
-Carpentries workshop, in which The Carpentries Core Team supports logistics and organisation for a fee
+Carpentries workshop, in which The Carpentries Core Team supports logistics and organisation for a fee.
 
 #### Certification
 
-process of earning a badge; refer to **_Badge, Checkout_**
+process of earning a badge; refer to **_Badge, Checkout_**.
 
 #### Checkout
 
-a process consisting of steps to be completed after, or in addition to, training to complete certification; most often, this refers to the [Instructor checkout process](https://carpentries.github.io/instructor-training/14-checkout.html), but may also refer to [steps required for Instructor Trainer certification](https://carpentries.github.io/trainer-training/index.html)
+a process consisting of steps to be completed after, or in addition to, training to complete certification; most often, this refers to the [Instructor checkout process](https://carpentries.github.io/instructor-training/14-checkout.html), but may also refer to [steps required for Instructor Trainer certification](https://carpentries.github.io/trainer-training/index.html).
 
 #### [Code of Conduct (CoC)](https://docs.carpentries.org/topic_folders/policies/index_coc.html)
 
-a policy that describes what is expected of everyone participating in Carpentries activities
+a policy that describes what is expected of everyone participating in Carpentries activities.
 
 #### Code of Conduct Committee
 
-members of the community who keep our community friendly and welcoming by processing and responding to reports of violations of our Code of Conduct
+members of the community who keep our community friendly and welcoming by processing and responding to reports of violations of our Code of Conduct.
 
 #### Collaboration Session
 
-community session providing dedicated time and space to co-develop a community resource or to co-work on any community activity
+community session providing dedicated time and space to co-develop a community resource or to co-work on any community activity.
 
 #### Collaborative Lesson Development Training
 
-training in how to design and develop open source curriculum using The Carpentries lesson infrastructure; a necessary step to complete Lesson Developer certification
+training in how to design and develop open source curriculum using The Carpentries lesson infrastructure; a necessary step to complete Lesson Developer certification.
 
 #### Committee
 
-group of community members appointed for a specific function (e.g., Curriculum Advisory Committee); [The Carpentries Committee Guidelines](https://docs.carpentries.org/resources/general/committees.html) provide the recommended process for creating committees to ensure transparency, accountability, and sustainability of committee activities
+group of community members appointed for a specific function (e.g., Curriculum Advisory Committee); [The Carpentries Committee Guidelines](https://docs.carpentries.org/resources/general/committees.html) provide the recommended process for creating committees to ensure transparency, accountability, and sustainability of committee activities.
 
 #### Community 
 
-a network of regional and role-based volunteers, practitioners, and advocates who advance research by emphasizing the critical role of software and data; also see __Community Member__
+a network of regional and role-based volunteers, practitioners, and advocates who advance research by emphasizing the critical role of software and data; also see __Community Member__.
 
 #### Community Calendar
 
-[Google calendar](https://carpentries.org/community/#community-events) that includes all Carpentries events
+[Google calendar](https://carpentries.org/community/#community-events) that includes all Carpentries events.
 
 
 #### Community Development Program (CDP)
 
-the program is supported by the Community Engagement Team and offers resources and services to support community leaders who are building new or sustaining existing subcommunities (i.e., Subcommunity Coordinators); the primary goal of the program is to improve how subcommunities are supported to maximise benefits to our community members and to ensure the long term sustainability of the organisation as we continue to grow globally
+the program is supported by the Community Engagement Team and offers resources and services to support community leaders who are building new or sustaining existing subcommunities (i.e., Subcommunity Coordinators); the primary goal of the program is to improve how subcommunities are supported to maximise benefits to our community members and to ensure the long term sustainability of the organisation as we continue to grow globally.
 
 #### Community Engagement Team (CET)
 
@@ -111,99 +115,95 @@ The Community Engagement Team is responsible for all aspects of the Community De
 
 #### Community Discussion Session
 
-structured or flexibly structured community session on any topic relevant to the community that can be in any format of the host’s choosing
+structured or flexibly structured community session on any topic relevant to the community that can be in any format of the host’s choosing.
 
 #### Community Member
 
-an individual who actively participates in The Carpentries' activities, contributing to its mission of emphasising the critical role of software and data in advancing research. Roles include learners, Instructors, Maintainers, and Trainers, all committed to fostering an inclusive, collaborative, and supportive learning environment.
+an individual who actively participates in The Carpentries' activities, contributing to its mission of emphasising the critical role of software and data in advancing research. Roles include learners, Instructors, Maintainers, and instructor Trainers, all committed to fostering an inclusive, collaborative, and supportive learning environment.
 
 #### Community Session
 
-community event designed for everyone in The Carpentries community interested in learning, educating and advocating for teaching foundational coding and data science skills globally; there are three types of community Sessions: Community Discussion Sessions, Skill-up Sessions, and Collaboration Sessions; The Carpentries Community Engagement Team manages Community Sessions which are led by Community Session Hosts
+community event designed for everyone in The Carpentries community interested in learning, educating and advocating for teaching foundational coding and data science skills globally; there are three types of community Sessions: Community Discussion Sessions, Skill-up Sessions, and Collaboration Sessions; The Carpentries Community Engagement Team manages Community Sessions which are led by Community Session Hosts.
 
 #### Community Session Host
 
-member of The Carpentries community who facilitates a Community Session
+member of The Carpentries community who facilitates a Community Session.
 
 #### Core Team
 
-team members whose primary professional focus is to support the overall mission of The Carpentries; include employees of our fiscal sponsor, Community Initiatives, or the professional employer organisation (PEO), Velocity Global; these individuals are fully integrated into The Carpentries operational systems, attend weekly meetings, and function as part of programmatic teams
+team members whose primary professional focus is to support the overall mission of The Carpentries; they are employed through a professional employer organisation (PEO), Deel; these individuals are fully integrated into The Carpentries operational systems, attend weekly meetings, and function as part of programmatic teams.
 
 #### Cultural Competence
 
-state of having and applying knowledge and skill in four areas: (1) awareness of one’s cultural worldview; (2) recognition of one’s attitudes toward cultural differences; (3) realisation  of different cultural practices and worldviews; and (4) thoughtfulness in cross-cultural interaction
+state of having and applying knowledge and skill in four areas: (1) awareness of one’s cultural worldview; (2) recognition of one’s attitudes toward cultural differences; (3) realisation  of different cultural practices and worldviews; and (4) thoughtfulness in cross-cultural interaction.
 
 #### Curriculum
 
-self-contained set of one or more lessons that are aimed at a given target audience and designed to be taught together in a workshop or training
+self-contained set of one or more lessons that are aimed at a given target audience and designed to be taught together in a workshop or training.
 
 #### Curriculum Advisor
 
-individual who volunteers to guide the development of existing lessons, maintain a broad perspective on the state of the field, and make strategic decisions about major changes to a lesson
+individual who volunteers to guide the development of existing lessons, maintain a broad perspective on the state of the field, and make strategic decisions about major changes to a lesson.
 
 #### Curriculum Advisory Committee (CAC)
 
-group of Curriculum Advisors serving a single curriculum
+group of Curriculum Advisors serving a single curriculum.
 
 #### Curriculum Development Handbook
 
-guide to the process and infrastructure used by The Carpentries community to develop new lessons
+guide to the process and infrastructure used by The Carpentries community to develop new lessons.
 
 #### Curriculum Module
 
-set of resources in the curriculum addressing one topic such as Code of Conduct facilitation
+set of resources in the curriculum addressing one topic such as Code of Conduct facilitation.
 
 #### Curriculum Team
 
-members of The Carpentries Core Team who guide and oversee curriculum development and maintenance and work closely with our Lesson Maintainers and Curriculum Advisors
+members of The Carpentries Core Team who guide and oversee curriculum development and maintenance and work closely with our Lesson Maintainers and Curriculum Advisors.
 
 
 ## D
 
 #### Demo
 
-refer to **_Teaching Demo_**
+refer to **_Teaching Demo_**.
 
 
 #### Discussion Host 
 
-member of The Carpentries community who facilitated a community discussion; now known as Community Session Host
+member of The Carpentries community who facilitated a community discussion; now known as Community Session Host.
 
 
 #### Diversity
 
-individual differences (e.g., personality, language, learning preferences and life experiences) and group-social differences (e.g., race, ethnicity, class, gender, gender identity, sexual orientation, sexual identity, country of origin and ability status, as well as cultural, political, religious or other affiliations) that can be engaged in the service of learning
+individual differences (e.g., personality, language, learning preferences and life experiences) and group-social differences (e.g., race, ethnicity, class, gender, gender identity, sexual orientation, sexual identity, country of origin and ability status, as well as cultural, political, religious or other affiliations) that can be engaged in the service of learning.
 
 #### Donor
 
-an individual who contributes financially to The Carpentries, whether one-time or regularly
+an individual who contributes financially to The Carpentries, whether one-time or regularly.
 
 
 ## E
 
 #### Editor
 
-coordinates and oversees the open peer review of lessons in The Carpentries Lab
+coordinates and oversees the open peer review of lessons in The Carpentries Lab.
 
 #### Episode (Lesson Episode)
 
-a single page in the body of a Carpentries lesson; multiple episodes make up a lesson; an episode does not need to be self-contained
+a single page in the body of a Carpentries lesson; multiple episodes make up a lesson; an episode does not need to be self-contained.
 
 #### Equity
 
-creation of opportunities for access to and participation in programs that are capable of closing participation gaps in our community
+creation of opportunities for access to and participation in programs that are capable of closing participation gaps in our community.
 
 #### Etherpad
 
-open-source, web-based collaborative real-time editor; allows authors to edit a text document simultaneously and access all of the participants' edits in real-time, with the ability to display each author's text in a different colour; there is also a chat box in the sidebar to allow meta communication
-
-#### Executive Council 
-
-the former governing body of The Carpentries, to whom the Executive Director reports; comprises nine members from The Carpentries community or others, four elected by the community, and five appointed by the Executive Council; the highest leadership body of The Carpentries project responsible for strategic and organisational planning, selecting the Executive Director and evaluating their performance, financial oversight, identifying revenue streams and resource development, approving and monitoring The Carpentries programs and services, and enhancing The Carpentries public image; members of the council also serve as advocates and ambassadors for the organisation, leveraging their networks to benefit the project’s reputation and fundraising; executes these responsibilities through a combination of quarterly Executive Council meetings and regular correspondence and collaboration via email and online platforms
+open-source, web-based collaborative real-time editor; allows authors to edit a text document simultaneously and access all of the participants' edits in real-time, with the ability to display each author's text in a different colour; there is also a chat box in the sidebar to allow meta communication.
 
 #### Executive Team
 
-members of the Core Team who proactively bring together perspectives from all individual programmatic teams and established community segments; they discuss and resolve ongoing challenges, develop and implement a shared approach to management and leadership, review and make decisions on budget, oversee and make decisions on Core Team roles and responsibilities, establish and support how the Core Team works together, oversee project work, support the development of revenue opportunities including grants, and support the Executive Director in their work with the Executive Council 
+members of the Core Team who proactively bring together perspectives from all individual programmatic teams and established community segments; they discuss and resolve ongoing challenges, develop and implement a shared approach to management and leadership, review and make decisions on budget, oversee and make decisions on Core Team roles and responsibilities, establish and support how the Core Team works together, oversee project work, support the development of revenue opportunities including grants, and support the Executive Director in their work with the Board of Directors. 
 
 
 ## F
@@ -213,81 +213,77 @@ members of the Core Team who proactively bring together perspectives from all in
 
 #### Governance
 
-system by which an organisation is controlled and operates; governance of The Carpentries is undertaken by the Executive Council, to whom the Executive Director reports; refer to **_Executive Council_**
+system by which an organisation is controlled and operates; governance of The Carpentries is undertaken by the Board of Directors, to whom the Executive Director reports; refer to **_Board of Directors_**.
 
 #### Gratitudes
 
-opportunities available for the community to share an appreciation for each other and all that we have been able to accomplish together; a gratitudes section is included in every newsletter; [a customized emoji](https://github.com/carpentries/logo/blob/main/Carpentries%20Gratitude%20Emoji.png) is also available to share gratitude in Slack or social media
+opportunities available for the community to share an appreciation for each other and all that we have been able to accomplish together; a gratitudes section is included in every newsletter; [a customized emoji](https://github.com/carpentries/logo/blob/main/Carpentries%20Gratitude%20Emoji.png) is also available to share gratitude in Slack or social media.
 
 #### Green Sticky
 
-positive feedback from the community or for the community
+positive feedback from the community or for the community.
 
 
 ## H
 
 #### Handbook
 
-refer to **_Carpentries Handbook_**
+refer to **_Carpentries Handbook_**.
 
 #### Helper
 
-volunteer recruited by the workshop organiser to support Carpentries workshops; support learners one-on-one if they are stuck installing software, understanding a line of code, or any other parts of the learning process; does not have to be a certified Instructor or member of The Carpentries community; refer to [helper checklist](https://docs.carpentries.org/topic_folders/hosts_instructors/hosts_instructors_checklist.html#helper-checklist) for more information
+volunteer recruited by the workshop organiser to support Carpentries workshops; support learners one-on-one if they are stuck installing software, understanding a line of code, or any other parts of the learning process; does not have to be a certified Instructor or member of The Carpentries community; refer to [helper checklist](https://docs.carpentries.org/topic_folders/hosts_instructors/hosts_instructors_checklist.html#helper-checklist) for more information.
 
 #### Host Organisation(s)
 
-organisation(s) responsible for organising a Carpentries event; the organisation where the event is held
+organisation(s) responsible for organising a Carpentries event; the organisation where the event is held.
 
 
 ## I
 
 #### Incident Response Group (IRG)
 
-group of people who work on a specific code of conduct incident; there will be a minimum of three people from the Code of Conduct committee on each IRG
+group of people who work on a specific code of conduct incident; there will be a minimum of three people from the Code of Conduct committee on each IRG.
 
 #### Incident Response Lead
 
-a person on the Code of Conduct committee heading the Incidence Response Group (IRG); this person is appointed on a per-incident basis by the IRG
+a person on the Code of Conduct committee heading the Incidence Response Group (IRG); this person is appointed on a per-incident basis by the IRG.
 
 #### Inclusion
 
-active, intentional, and ongoing engagement of diverse people and communities that increases awareness, content knowledge, and empathic understanding of the ways we interact within (and change) our community
+active, intentional, and ongoing engagement of diverse people and communities that increases awareness, content knowledge, and empathic understanding of the ways we interact within (and change) our community.
 
 #### Incubator
 
-refer to **_Carpentries Incubator_**
+refer to **_Carpentries Incubator_**.
 
 #### Incubator Lesson
 
-lesson under development by the community in The Carpentries Incubator, using the Carpentries lesson infrastructure
-
-#### Incubator Lesson Spotlight
-
-a feature in The Carpentries blog and newsletter, highlighting a lesson currently under community development; the purpose is to raise the visibility of that lesson among the broader community and to encourage community members to contribute to its further development
+lesson under development by the community in The Carpentries Incubator, using the Carpentries lesson infrastructure.
 
 #### Instructors
 
-community members who are certified to teach Carpentries workshops after completing Instructor Training and checkout
+community members who are certified to teach Carpentries workshops after completing Instructor Training and checkout.
 
 #### Instructor Meeting
 
-every other month meetings where Instructors discuss pre/post workshops, challenges and wins, and receive important announcements from the Core Team
+every other month meetings where Instructors discuss pre/post workshops, challenges and wins, and receive important announcements from the Core Team.
 
 #### Instructor Trainee
 
-individual who is in the process of being certified as an Instructor
+individual who is in the process of being certified as an Instructor.
 
 #### Instructor Trainer
 
-community member who has been trained and certified to teach Instructor Training; they also host teaching demonstrations, attend Instructor Trainer meetings, and teach Instructor Training Bonus Modules 
+community member who has been trained and certified to teach Instructor Training; they also host teaching demonstrations, attend Instructor Trainer meetings, and teach Instructor Training Bonus Modules.
 
 #### Instructor Training
 
-training in how to teach Carpentries workshops, including educational psychology, evidence-based teaching practices, and Carpentries-specific information; a necessary step for completing Instructor checkout and certification; refer to **_Instructor Training Curriculum_**
+training in how to teach Carpentries workshops, including educational psychology, evidence-based teaching practices, and Carpentries-specific information; a necessary step for completing Instructor checkout and certification; refer to **_Instructor Training Curriculum_**.
 
 #### Internationalisation
 
-initiative to translate Carpentries resources into multiple languages and support the adoption of The Carpentries internationally; sometimes abbreviated as "i18n" where 18 stands for the number of letters between the first “i” and the last “n” in the word internationalisation
+initiative to translate Carpentries resources into multiple languages and support the adoption of The Carpentries internationally; sometimes abbreviated as "i18n" where 18 stands for the number of letters between the first “i” and the last “n” in the word internationalisation.
 
 
 ## J
@@ -300,7 +296,7 @@ initiative to translate Carpentries resources into multiple languages and suppor
 
 #### Lab
 
-refer to **_Carpentries Lab_**
+refer to **_Carpentries Lab_**.
 
 #### Lab Lesson
 
@@ -308,99 +304,99 @@ peer-reviewed lesson in The Carpentries Lab; lab lessons typically begin in the 
 
 #### Learner
 
-anyone who participates in a Carpentries workshop
+anyone who participates in a Carpentries workshop.
 
 #### Lesson
 
-self-contained collection of episodes teaching skills within a single topic, built using the Lesson Infrastructure
+self-contained collection of episodes teaching skills within a single topic, built using the Lesson Infrastructure.
 
 #### Lesson Developer
 
-member of the community who creates lesson content; may use Curriculum Development Handbook as a primary resource
+member of the community who creates lesson content; may use Curriculum Development Handbook as a primary resource.
 
 #### Lesson Developer Trainer
 
-member of the community who has been trained and certified to teach Collaborative Lesson Development Training; they also attend Lesson Developer Trainer meetings
+member of the community who has been trained and certified to teach Collaborative Lesson Development Training; they also attend Lesson Developer Trainer meetings.
 
 #### Lesson Development Sprint
 
-dedicated event to make progress and encourage collaboration on the development of a lesson
+dedicated event to make progress and encourage collaboration on the development of a lesson.
 
 #### Lesson Infrastructure
 
-collection of software tools that are used to build, style, and validate a Carpentries lesson website; also known as The Carpentries Workbench
+collection of software tools that are used to build, style, and validate a Carpentries lesson website; also known as The Carpentries Workbench.
 
 #### Lesson Infrastructure Committee
 
-members of the community who make decisions for structural changes to the lesson infrastructure to ensure that they align with our core values
+members of the community who make decisions for structural changes to the lesson infrastructure to ensure that they align with our core values.
 
 #### Lesson Maintainer
 
-refer to **_Maintainer_**
+refer to **_Maintainer_**.
 
 #### Lesson Program
 
-collection of lessons (i.e Data Carpentry, Library Carpentry and Software Carpentry lessons) which comprise one or more Carpentries workshops and the leadership guiding their development and implementation; [lesson programs are described in further detail in The Carpentries Handbook](https://docs.carpentries.org/topic_folders/governance/lesson-program-policy.html#lesson-programs_)
+collection of lessons (i.e Data Carpentry, Library Carpentry and Software Carpentry lessons) which comprise one or more Carpentries workshops and the leadership guiding their development and implementation; [lesson programs are described in further detail in The Carpentries Handbook](https://docs.carpentries.org/topic_folders/governance/lesson-program-policy.html#lesson-programs_).
 
 #### Lesson Program Governance Committee
 
-group overseeing the strategy and policies of a Lesson Program 
+group overseeing the strategy and policies of a Lesson Program. 
 
 #### Liaison
 
-representative of the Core Team who sits on a committee or task force to support the group's work 
+representative of the Core Team who sits on a committee or task force to support the group's work. 
 
 #### Local Subcommunity
 
-members of a local subcommunity within a specific geographic region; refer to **_Subcommunity_**
+members of a local subcommunity within a specific geographic region; refer to **_Subcommunity_**.
 
 #### Listserv
 
-refer to **_Mailing List_**
+refer to **_Mailing List_**.
 
 
 ## M
 
 #### Mailing List
 
-email list you can subscribe to for receiving communications from the community; [TopicBox](#topicbox) is the platform The Carpentries uses for supporting mailing lists
+email list you can subscribe to for receiving communications from the community; [TopicBox](#topicbox) is the platform The Carpentries uses for supporting mailing lists.
 
 #### Maintainer
 
-community member working to keep Carpentries lessons stable and functional
+community member working to keep Carpentries lessons stable and functional.
 
 #### Membership
 
-refer to **_Member Organisation_**
+refer to **_Member Organisation_**.
 
 #### Member Organisation
 
-an institution committed to supporting the maintenance and growth of The Carpentries community according to the specific details outlined in each institution’s Membership Agreement or Memorandum of Agreement 
+an institution committed to supporting the maintenance and growth of The Carpentries community according to the specific details outlined in each institution’s Membership Agreement or Memorandum of Agreement. 
 
 
 ## N
 
 #### Newsletter
 
-communication sent to an opt-in mailing list each month, featuring community news and announcements and including important updates from The Carpentries committees, task forces and programs, job postings, and related information for our community from other organisations; refer to **_Carpentries Clippings_**
+communication sent to an opt-in mailing list each month, featuring community news and announcements and including important updates from The Carpentries committees, task forces and programs, job postings, and related information for our community from other organisations; refer to **_Carpentries Clippings_**.
 
 
 ## O
 
 #### Official Lesson
 
-the single lesson within a Lesson Program that can be taught in an official Carpentries workshop
+the single lesson within a Lesson Program that can be taught in an official Carpentries workshop.
 
 
 ## P
 
 #### Pilot Workshop
 
-event where a new lesson is being tested
+event where a new lesson is being tested.
 
 #### Policy
 
-guideline adopted by The Carpentries that informs the implementation of procedures, including but not limited to, finances, infrastructure, and programming; for more information on our policies, refer to [policies in The Carpentries handbook](https://docs.carpentries.org/topic_folders/policies/index.html)
+guideline adopted by The Carpentries that informs the implementation of procedures, including but not limited to, finances, infrastructure, and programming; for more information on our policies, refer to [policies in The Carpentries handbook](https://docs.carpentries.org/topic_folders/policies/index.html).
 
 
 ## Q
@@ -410,102 +406,102 @@ guideline adopted by The Carpentries that informs the implementation of procedur
 
 #### Red Sticky
 
-constructive feedback from the community or for the community
+constructive feedback from the community or for the community.
 
 #### Regional Community Call
 
-community session of regional subcommunity matters 
+community session of regional subcommunity matters. 
 
 #### Reviewer
 
-community member providing feedback on a lesson as part of The Carpentries Lab's open peer review process
+community member providing feedback on a lesson as part of The Carpentries Lab's open peer review process.
 
 #### Roadmap
 
-plan that defines a goal or desired outcome and includes the major steps or milestones needed to achieve it
+plan that defines a goal or desired outcome and includes the major steps or milestones needed to achieve it.
 
 
 ## S
 
 #### Self-Organised Workshop
 
-workshop that is facilitated and organised by a certified Carpentries Instructor and their local community
+workshop that is facilitated and organised by a certified Carpentries Instructor and their local community.
 
 #### Skill-Up Session
 
-community session offering professional development opportunities for the community where the Community Session Host teaches relevant skills
+community session offering professional development opportunities for the community where the Community Session Host teaches relevant skills.
 
 #### Slack
 
-software platform used by The Carpentries to support synchronous and asynchronous communications; channels support communications, collaboration and co-creation among a subset of community members, depending on the channel’s purpose
+software platform used by The Carpentries to support synchronous and asynchronous communications; channels support communications, collaboration and co-creation among a subset of community members, depending on the channel’s purpose.
 
 #### Sponsor
 
-an organisation that has committed to supporting The Carpentries financially through the Carpentries Sponsorship program; refer to **_Sponsorship Program_** 
+an organisation that has committed to supporting The Carpentries financially through the Carpentries Sponsorship program; refer to **_Sponsorship Program_**. 
 
 #### Sponsorship Program
 
-program that allows a company, firm, or other entity to contribute financially to The Carpentries 
+program that allows a company, firm, or other entity to contribute financially to The Carpentries. 
 
 #### Strategic Plan
 
-document used to communicate The Carpentries' goals, objectives, and actions taken to achieve those goals over a three to five-year period
+document used to communicate The Carpentries' goals, objectives, and actions taken to achieve those goals over a three to five-year period.
 
 #### Subcommunity
 
-a subset of the larger Carpentries community; can be local, regional, domain-specific, or a group of community members sharing a common language or interests 
+a subset of the larger Carpentries community; can be local, regional, domain-specific, or a group of community members sharing a common language or interests. 
 
 #### Subcommunity Coordinator
 
-member of the community who serves as leader of a subcommunity 
+member of the community who serves as leader of a subcommunity.
 
 #### Subcommunity Registry
 
-a registry of all The Carpentries subcommunities who have officially registered with the organisation
+a registry of all The Carpentries subcommunities who have officially registered with the organisation.
 
 
 ## T
 
 #### Task Force
 
-group created to explore ideas and make updates in policy, procedures and guidelines; they bring together a small group of people focused on a particular topic for a set period
+group created to explore ideas and make updates in policy, procedures and guidelines; they bring together a small group of people focused on a particular topic for a set period.
 
 
 #### Teaching Demo
 
-a session where Instructor Trainees give a short demonstration of how they would teach a lesson; part of the Instructor certification process
+a session where Instructor Trainees give a short demonstration of how they would teach a lesson; part of the Instructor certification process.
 
 #### Technology Team
 
-members of The Carpentries Core Team that ensure the development, maintenance, and compliance of all the systems that keep our organisation operating (e.g., Etherpads, lesson templates, our internal database AMY)
+members of The Carpentries Core Team that ensure the development, maintenance, and compliance of all the systems that keep our organisation operating (e.g., Etherpads, lesson templates, our internal database AMY).
 
 #### Tip Sheet
 
-community resource that synthesises and summarises information; example includes our [Welcome Tip Sheet](https://carpentries.org/welcome-tip-sheet/)
+community resource that synthesises and summarises information; example includes our [Welcome Tip Sheet](https://carpentries.org/welcome-tip-sheet/).
 
 #### TopicBox
 
-platform The Carpentries uses for supporting email mailing lists; there are numerous mailing lists you can join based on the community roles you are supporting and your interests
+platform The Carpentries uses for supporting email mailing lists; there are numerous mailing lists you can join based on the community roles you are supporting and your interests.
 
 #### Trainee
 
-an individual who has registered for or attended a Carpentries Training (e.g., Instructor Training, Instructor Trainer Training) but has not yet completed certification; refer to **_Instructor Trainee_**
+an individual who has registered for or attended a Carpentries Training (e.g., Instructor Training, Instructor Trainer Training) but has not yet completed certification; refer to **_Instructor Trainee_**.
 
 #### Trainer
 
-community member who teaches a Carpentries Training; refer to **_Instructor Trainer_**
+community member who teaches a Carpentries Training; refer to **_Instructor Trainer_**.
 
 #### Instructor Trainers Leadership
 
-committee of Instructor Trainers responsible for community oversight and governance
+committee of Instructor Trainers responsible for community oversight and governance.
 
 #### Instructor Trainer Training
 
-training in how to teach Instructor Training; a necessary step to complete Instructor Trainer checkout and certification 
+training in how to teach Instructor Training; a necessary step to complete Instructor Trainer checkout and certification. 
 
 #### Training
 
-event that provides instruction on specific competencies, knowledge, or skills; individuals who complete training become eligible for certification upon completion of the program requirements; for example, refer to **_Instructor Training_**
+event that provides instruction on specific competencies, knowledge, or skills; individuals who complete training become eligible for certification upon completion of the program requirements; for example, refer to **_Instructor Training_**.
 
 
 ## U
@@ -519,39 +515,39 @@ event that provides instruction on specific competencies, knowledge, or skills; 
 
 #### Welcome Session
 
-a special type of Community Discussion Session to welcome new members of the community to our organisation; the agenda includes time for networking, covers ways to engage with our organisation, and includes announcements and upcoming opportunities; it also supports onboarding for those who recently completed Instructor training and onboarding for new member organisations
+a special type of Community Discussion Session to welcome new members of the community to our organisation; the agenda includes time for networking, covers ways to engage with our organisation, and includes announcements and upcoming opportunities; it also supports onboarding for those who recently completed Instructor training.
 
 #### Workbench
 
-the collection of three packages used to build Carpentries lessons: [sandpaper](https://carpentries.github.io/sandpaper), [pegboard](https://carpentries.github.io/pegboard), [varnish](https://carpentries.github.io/varnish); refer to **_Lesson Infrastructure_**
+the collection of three packages used to build Carpentries lessons: [sandpaper](https://carpentries.github.io/sandpaper), [pegboard](https://carpentries.github.io/pegboard), [varnish](https://carpentries.github.io/varnish); refer to **_Lesson Infrastructure_**.
 
 #### Workshop
 
-event that is taught by Carpentries Instructors who teach the curriculum of Data Carpentry, Library Carpentry and Software Carpentry; refer to **_Self-Organised Workshop_** and **_Centrally-Organised Workshop_**
+event that is taught by Carpentries Instructors who teach the curriculum of Data Carpentry, Library Carpentry and Software Carpentry; refer to **_Self-Organised Workshop_** and **_Centrally-Organised Workshop_**.
 
 #### Workshop Administrator
 
-role within The Carpentries Core Team that supports the organisation and execution of workshops requested by members and hosts
+role within The Carpentries Core Team that supports the organisation and execution of workshops requested by members and hosts.
 
 #### Workshops and Instruction Team
 
-members of The Carpentries Core Team who develop and implement workflows to keep our workshops operating smoothly. The team also supports the growth and development of the Instructor Training and Instructor Trainer Training programs 
+members of The Carpentries Core Team who develop and implement workflows to keep our workshops operating smoothly. The team also supports the growth and development of the Instructor Training and Instructor Trainer Training programs.
 
 #### Workshop Format
 
-how a workshop is delivered, either online, in-person, or hybrid
+how a workshop is delivered, either online, in-person, or hybrid.
 
 #### Workshop Host
 
-a person that organises a Carpentries workshop on behalf of their institution and requests a Centrally-Organised Workshop to be coordinated by a Workshop Administrator 
+a person that organises a Carpentries workshop on behalf of their institution and requests a Centrally-Organised Workshop to be coordinated by a Workshop Administrator. 
 
 #### Workshop Slug
 
-the specific name identifier for a workshop with the format yyyy-mm-dd-site-format
+the specific name identifier for a workshop with the format yyyy-mm-dd-site-format.
 
 #### Workshop Website
 
-a link that is used for the public to learn about a workshop; the link shares information such as date, location, how to register, the name of Instructors and helpers, the curriculum, contact information, workshop surveys, and instructions on how to pre-install software
+a link that is used for the public to learn about a workshop; the link shares information such as date, location, how to register, the name of Instructors and helpers, the curriculum, contact information, workshop surveys, and instructions on how to pre-install software.
 
 
 ## X
@@ -563,7 +559,7 @@ a link that is used for the public to learn about a workshop; the link shares in
 ## Z
 
 #### Zoom
-video conferencing platform; The Carpentries offers three Zoom rooms for public community events such as instructor training, community discussions, teaching demos, and committee meetings 
+video conferencing platform; The Carpentries offers three Zoom rooms for public community events such as Instructor training, community discussions, teaching demos, and committee meetings. 
 
 ## 
 
@@ -572,128 +568,135 @@ video conferencing platform; The Carpentries offers three Zoom rooms for public 
 
 #### Accessibility Facilitator
 
-inactive community service role within the Community Facilitators program; accessibility facilitators would lead conversations to review, update and implement Carpentries accessibility guidelines that guide interactions in online and in-person spaces, as well as the creation of written and audio-visual content and choice of platforms
-
+inactive community service role within the Community Facilitators program; accessibility facilitators would lead conversations to review, update and implement Carpentries accessibility guidelines that guide interactions in online and in-person spaces, as well as the creation of written and audio-visual content and choice of platforms.
 #### Assessment Network
 
-inactive committee that consisted of community members helping The Carpentries understand and assess the organisation’s impact
+inactive committee that consisted of community members helping The Carpentries understand and assess the organisation’s impact.
 
 #### Bonus Module
 
-refer to **_Instructor Training Bonus Module_**
+refer to **_Instructor Training Bonus Module_**.
 
 #### Buddy
 
-see **_Community Buddy_**
+see **_Community Buddy_**.
 
 #### Business Team
 
-members of The Carpentries Core Team who work on the legal and financial aspects of the organisation and coordinate with our funders and sponsors
+members of The Carpentries Core Team who work on the legal and financial aspects of the organisation and coordinate with our funders and sponsors.
 
 #### Carpentries Conversations
 
-community discussion hosted by one of our committees or task forces to provide the community with the opportunity to learn about and discuss new developments and programs in our organisation; now broadly referred to as Community Discussion Session
+community discussion hosted by one of our committees or task forces to provide the community with the opportunity to learn about and discuss new developments and programs in our organisation; now broadly referred to as Community Discussion Session.
 
 #### CarpentryCon @Home
 
-CarpentryCon event in 2020 held virtually; refer to **_CarpentryCon_**
+CarpentryCon event in 2020 held virtually; refer to **_CarpentryCon_**.
 
 #### Champion
 
-community member who helped support the growth and development of The Carpentries by advocating and connecting with local communities; the Champions program is currently inactive
+community member who helped support the growth and development of The Carpentries by advocating and connecting with local communities; the Champions program is currently inactive.
 
 #### Code of Conduct Facilitator
 
-inactive community service role within the Community Facilitators program; community facilitators who serve as a bridge between community members at events and our Code of Conduct processes
+inactive community service role within the Community Facilitators program; community facilitators who serve as a bridge between community members at events and our Code of Conduct processes.
 
 #### Cohort
 
-community members trained in any community role who are onboarded at the same time and who then work together to develop relevant community-facing resources that address specific needs
+community members trained in any community role who are onboarded at the same time and who then work together to develop relevant community-facing resources that address specific needs.
 
 #### Community Buddy
 
-member of the community who onboards new community members
+member of the community who onboards new community members.
 
 #### Communications Facilitator
 
-community facilitator who helped translate key communications so we could share these in languages other than English across our social media channels and lead region-specific outreach campaigns
+community facilitator who helped translate key communications so we could share these in languages other than English across our social media channels and lead region-specific outreach campaigns.
 
 #### Community Facilitator
 
-inactive community service role within the Community Facilitators program; community members who were trained to use the Community Facilitators Program curriculum
+inactive community service role within the Community Facilitators program; community members who were trained to use the Community Facilitators Program curriculum.
 
 #### Community Facilitators Program
 
-initiative in The Carpentries that sought to create new pathways for active involvement in everyday community activities by more community members; this program has been merged into the Community Development Program
+initiative in The Carpentries that sought to create new pathways for active involvement in everyday community activities by more community members; this program has been merged into the Community Development Program.
 
 #### Community Initiatives
 
-fiscal sponsor of The Carpentries
+fiscal sponsor of The Carpentries from from 2018-2024.
 
 #### Discussion Host 
 
-member of The Carpentries community who facilitated a community discussion; now known as Community Session Host
+member of The Carpentries community who facilitated a community discussion; now known as Community Session Host.
+
+#### Executive Council 
+
+the former governing body of The Carpentries, to whom the Executive Director reports; comprises nine members from The Carpentries community or others, four elected by the community, and five appointed by the Executive Council; the highest leadership body of The Carpentries project responsible for strategic and organisational planning, selecting the Executive Director and evaluating their performance, financial oversight, identifying revenue streams and resource development, approving and monitoring The Carpentries programs and services, and enhancing The Carpentries public image; members of the council also serve as advocates and ambassadors for the organisation, leveraging their networks to benefit the project’s reputation and fundraising; executes these responsibilities through a combination of quarterly Executive Council meetings and regular correspondence and collaboration via email and online platforms.
 
 #### Feedback Facilitator
 
-community facilitator who collected and organised feedback shared publicly and informally in our community spaces for ease of filtering, action and response 
+community facilitator who collected and organised feedback shared publicly and informally in our community spaces for ease of filtering, action and response.
+
+#### Incubator Lesson Spotlight
+
+a feature in The Carpentries blog and newsletter, highlighting a lesson currently under community development; the purpose is to raise the visibility of that lesson among the broader community and to encourage community members to contribute to its further development.
 
 #### Post-Training Framework
 
-a resource created by the Task Force to guide Community Facilitators in identifying needs in The Carpentries community that they can collaboratively work to alleviate in their cohort after their training
+a resource created by the Task Force to guide Community Facilitators in identifying needs in The Carpentries community that they can collaboratively work to alleviate in their cohort after their training.
 
 #### Regional Coordinator 
 
-member of the community who managed workshop logistics, communicated with hosts and Instructors and responded to general inquiries
+member of the community who managed workshop logistics, communicated with hosts and Instructors and responded to general inquiries.
 
 #### Resource-Enhancement Facilitator
 
-community facilitator who led discussions around content design to guide the publication and archiving of community-created resources in a way that makes them accessible to all, and lowers barriers to knowledge acquisition by other community members i.e. replacing sea of text with images, GIFs, and videos, illustrating workflows to make them easier to understand, managing tags and their use to collate resources across Carpentries platforms, etc
+community facilitator who led discussions around content design to guide the publication and archiving of community-created resources in a way that makes them accessible to all, and lowers barriers to knowledge acquisition by other community members i.e. replacing sea of text with images, GIFs, and videos, illustrating workflows to make them easier to understand, managing tags and their use to collate resources across Carpentries platforms, etc.
 
 #### Technology Facilitator
 
-community facilitator who addressed everyday ‘how-do-I’ questions that newcomers have as they collaborate with others on platforms The Carpentries uses (i.e. GitHub)
+community facilitator who addressed everyday ‘how-do-I’ questions that newcomers have as they collaborate with others on platforms The Carpentries uses (i.e. GitHub).
 
 #### Infrastructure Team
 
-members of The Carpentries Core Team that ensure the development, maintenance, and compliance of all the systems that keep our organisation operating (e.g., Etherpads, lesson templates, our internal database AMY); now referred to as the Technology Team
+members of The Carpentries Core Team that ensure the development, maintenance, and compliance of all the systems that keep our organisation operating (e.g., Etherpads, lesson templates, our internal database AMY); now referred to as the Technology Team.
 
 #### Instructor Development Committee (IDC)
 
-inactive committee that developed and maintained a mentorship program to support Instructors as they progress through training, teaching, curriculum development, and other community-related activities; they helped promote community-building and networking by providing (virtual) spaces where Instructors from all over the world can share teaching success stories and discuss strategies for overcoming challenges
+inactive committee that developed and maintained a mentorship program to support Instructors as they progress through training, teaching, curriculum development, and other community-related activities; they helped promote community-building and networking by providing (virtual) spaces where Instructors from all over the world can share teaching success stories and discuss strategies for overcoming challenges.
 
 #### Instructor Training Bonus Module
 
-additional optional training that may be offered to Instructors 
+additional optional training that may be offered to Instructors. 
 
 #### Member Council
 
-group of representatives from Member Organisations that provide feedback and ideas to the Membership Team; each Member Organisation is allocated seats on the Member Council
+group of representatives from Member Organisations that provide feedback and ideas to the Membership Team; each Member Organisation is allocated seats on the Member Council.
 
 #### Membership Team
 
-members of The Carpentries Core Team who supported the growth and development of The Carpentries Membership Program; Membership is now supported by the Community Engagement Team
+members of The Carpentries Core Team who supported the growth and development of The Carpentries Membership Program; Membership is now supported by the Community Engagement Team.
 
 #### Mentee
 
-member of the Mentoring Program (now inactive) who is new to The Carpentries community and is supported by a Mentor
+member of the Mentoring Program (now inactive) who is new to The Carpentries community and is supported by a Mentor.
 
 #### Mentor
 
-Instructor who volunteered to guide small groups of mentees toward a particular outcome; the Mentoring Program is no longer active
+Instructor who volunteered to guide small groups of mentees toward a particular outcome; the Mentoring Program is no longer active.
 
 #### Mentoring Program
 
-an inactive program that supported Instructors who were new to our community by matching them with a personal Mentor and helped Mentees gain the confidence, technical skills, and teaching skills needed to achieve their goal
+an inactive program that supported Instructors who were new to our community by matching them with a personal Mentor and helped Mentees gain the confidence, technical skills, and teaching skills needed to achieve their goal.
 
 #### Pre- and Post-Workshop Discussion
 
-community discussion designed for Instructors getting ready to teach or having recently taught to discuss their workshop with other Instructors; now broadly referred to as Community Discussion Session 
+community discussion designed for Instructors getting ready to teach or having recently taught to discuss their workshop with other Instructors; now broadly referred to as Community Discussion Session. 
 
 #### Team
 
-group of Core Team members that work collaboratively to support a specific program area
+group of Core Team members that work collaboratively to support a specific program area.
 
 #### Themed Discussion Session
 
-community discussion centred around a particular topic (e.g., teaching your first workshop, community building strategies); now broadly referred to as a Community Discussion Session
+community discussion centred around a particular topic (e.g., teaching your first workshop, community building strategies); now broadly referred to as a Community Discussion Session.

--- a/glossary.md
+++ b/glossary.md
@@ -119,7 +119,7 @@ structured or flexibly structured community session on any topic relevant to the
 
 #### Community Member
 
-an individual who actively participates in The Carpentries' activities, contributing to its mission of emphasising the critical role of software and data in advancing research. Roles include learners, Instructors, Maintainers, and instructor Trainers, all committed to fostering an inclusive, collaborative, and supportive learning environment.
+an individual who actively participates in The Carpentries' activities, contributing to its mission of emphasising the critical role of software and data in advancing research. Roles include learners, Instructors, Maintainers, and Instructor Trainers, all committed to fostering an inclusive, collaborative, and supportive learning environment.
 
 #### Community Session
 


### PR DESCRIPTION
Made several stylistic changes in keeping with our style guide (full stops at end of all terms; British spelling, e.g.), archived outdated terms, and added and updated some terms to reflect the post-transition phase of the organisation.